### PR TITLE
Add RichTextEditor demo page

### DIFF
--- a/UEditor.sln
+++ b/UEditor.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UEditor.Docs.WebAssembly", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UEditor", "src\UEditor\UEditor.csproj", "{BC1EAC5D-51CD-4E1E-96E1-157242FE205F}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RichTextEditor", "src\RichTextEditor\RichTextEditor.csproj", "{F184DC66-B36B-493D-9E1B-47236C60F18E}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C09779F1-B3B0-49E4-A876-20B45AC724FC}"
 	ProjectSection(SolutionItems) = preProject
 		README.md = README.md
@@ -38,6 +40,10 @@ Global
 		{BC1EAC5D-51CD-4E1E-96E1-157242FE205F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BC1EAC5D-51CD-4E1E-96E1-157242FE205F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BC1EAC5D-51CD-4E1E-96E1-157242FE205F}.Release|Any CPU.Build.0 = Release|Any CPU
+                {F184DC66-B36B-493D-9E1B-47236C60F18E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {F184DC66-B36B-493D-9E1B-47236C60F18E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {F184DC66-B36B-493D-9E1B-47236C60F18E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {F184DC66-B36B-493D-9E1B-47236C60F18E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/RichTextEditor/RichTextEditor.csproj
+++ b/src/RichTextEditor/RichTextEditor.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+  <PropertyGroup>
+    <TargetFramework>net7</TargetFramework>
+    <RazorLangVersion>3.0</RazorLangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/RichTextEditor/RichTextEditor.razor
+++ b/src/RichTextEditor/RichTextEditor.razor
@@ -1,0 +1,37 @@
+<div class="rte-toolbar @ToolbarClass" style="@ToolbarStyle">
+    @if (_toolbarButtons.Contains("bold"))
+    {
+        <button type="button" @onclick='() => ExecCommand("bold")'><b>B</b></button>
+    }
+    @if (_toolbarButtons.Contains("italic"))
+    {
+        <button type="button" @onclick='() => ExecCommand("italic")'><i>I</i></button>
+    }
+    @if (_toolbarButtons.Contains("orderedList"))
+    {
+        <button type="button" @onclick='() => ExecCommand("insertOrderedList")'>OL</button>
+    }
+    @if (_toolbarButtons.Contains("unorderedList"))
+    {
+        <button type="button" @onclick='() => ExecCommand("insertUnorderedList")'>UL</button>
+    }
+    @if (_toolbarButtons.Contains("link"))
+    {
+        <button type="button" @onclick="CreateLink">Link</button>
+    }
+    @if (_toolbarButtons.Contains("image"))
+    {
+        <button type="button" @onclick="TriggerImageUpload">Img</button>
+    }
+    @if (_toolbarButtons.Contains("file"))
+    {
+        <button type="button" @onclick="TriggerFileUpload">File</button>
+    }
+    <InputFile @ref="_imageInput" style="display:none" OnChange="UploadImage" />
+    <InputFile @ref="_fileInput" style="display:none" OnChange="UploadFile" />
+</div>
+<div @ref="_ref" contenteditable="true"
+     @oninput="HandleInput" @onblur="HandleBlur" @onfocus="HandleFocus"
+     @onkeydown="HandleKeyDown" @onmouseup="HandleSelection" @onkeyup="HandleSelection"
+     style="width:@Width; height:@Height; @Style" class="@Class" id="@_id"
+     data-placeholder="@Placeholder">@((MarkupString)Html)</div>

--- a/src/RichTextEditor/RichTextEditor.razor.cs
+++ b/src/RichTextEditor/RichTextEditor.razor.cs
@@ -1,0 +1,256 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.JSInterop;
+using Microsoft.AspNetCore.Components.Forms;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace RichTextEditor
+{
+    public partial class RichTextEditor : ComponentBase, IDisposable
+    {
+        [Inject] private IJSRuntime Js { get; set; }
+        [Inject] private HttpClient Http { get; set; }
+
+        [Parameter] public string Value { get; set; }
+        [Parameter] public EventCallback<string> ValueChanged { get; set; }
+        [Parameter] public string Html { get; set; }
+        [Parameter] public EventCallback<string> HtmlChanged { get; set; }
+        [Parameter] public string Height { get; set; }
+        [Parameter] public string Width { get; set; }
+        [Parameter] public string Placeholder { get; set; }
+        [Parameter] public string Class { get; set; }
+        [Parameter] public string Style { get; set; }
+        [Parameter] public string UploadUrl { get; set; }
+        [Parameter] public string ToolbarClass { get; set; }
+        [Parameter] public string ToolbarStyle { get; set; }
+        [Parameter] public Dictionary<string, object> Options { get; set; } = new();
+        [Parameter] public EventCallback<string> OnFocus { get; set; }
+        [Parameter] public EventCallback<string> OnBlur { get; set; }
+        [Parameter] public EventCallback<string> OnEscPress { get; set; }
+        [Parameter] public EventCallback<string> OnCtrlEnterPress { get; set; }
+        [Parameter] public EventCallback<string> OnSelect { get; set; }
+
+        protected ElementReference _ref;
+        private InputFile _imageInput;
+        private InputFile _fileInput;
+        private List<string> _toolbarButtons = new() { "bold", "italic", "orderedList", "unorderedList", "link", "image", "file" };
+        protected readonly string _id = Guid.NewGuid().ToString();
+
+        protected override void OnInitialized()
+        {
+            Value ??= string.Empty;
+            Html ??= string.Empty;
+            Width ??= "100%";
+            Height ??= "200px";
+            Placeholder ??= string.Empty;
+            UploadUrl ??= "/api/upload";
+            Options ??= new Dictionary<string, object>();
+
+            if (Options.TryGetValue("ToolbarButtons", out var tb) && tb is IEnumerable<string> buttons)
+            {
+                _toolbarButtons = new List<string>(buttons);
+            }
+        }
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            await base.OnAfterRenderAsync(firstRender);
+            if (firstRender)
+            {
+                await Js.InvokeVoidAsync("BlazorRichTextEditor.setDimensions", _ref, Width, Height);
+                await Js.InvokeVoidAsync("BlazorRichTextEditor.setPlaceholder", _ref, Placeholder);
+                if (!string.IsNullOrEmpty(Html))
+                {
+                    await Js.InvokeVoidAsync("BlazorRichTextEditor.setHtml", _ref, Html);
+                }
+            }
+        }
+
+        private async Task HandleInput()
+        {
+            Value = await Js.InvokeAsync<string>("BlazorRichTextEditor.getText", _ref);
+            Html = await Js.InvokeAsync<string>("BlazorRichTextEditor.getHtml", _ref);
+
+            if (ValueChanged.HasDelegate)
+            {
+                await ValueChanged.InvokeAsync(Value);
+            }
+            if (HtmlChanged.HasDelegate)
+            {
+                await HtmlChanged.InvokeAsync(Html);
+            }
+        }
+
+        private async Task HandleBlur()
+        {
+            await HandleInput();
+            if (OnBlur.HasDelegate)
+            {
+                await OnBlur.InvokeAsync(Value);
+            }
+        }
+
+        private async Task HandleFocus()
+        {
+            if (OnFocus.HasDelegate)
+            {
+                await OnFocus.InvokeAsync(Value);
+            }
+        }
+
+        private async Task HandleKeyDown(KeyboardEventArgs e)
+        {
+            if (e.Key == "Escape" && OnEscPress.HasDelegate)
+            {
+                await OnEscPress.InvokeAsync(Value);
+            }
+            else if (e.Key == "Enter" && e.CtrlKey && OnCtrlEnterPress.HasDelegate)
+            {
+                await OnCtrlEnterPress.InvokeAsync(Value);
+            }
+        }
+
+        private async Task HandleSelection()
+        {
+            if (OnSelect.HasDelegate)
+            {
+                await OnSelect.InvokeAsync(Value);
+            }
+        }
+
+        private async Task ExecCommand(string command, string arg = null)
+        {
+            await Js.InvokeVoidAsync("BlazorRichTextEditor.execCommand", _ref, command, arg);
+            await HandleInput();
+        }
+
+        private async Task CreateLink()
+        {
+            await Js.InvokeVoidAsync("BlazorRichTextEditor.createLink", _ref);
+            await HandleInput();
+        }
+
+        private const long MaxFileSize = 1024 * 1024 * 15; // 15MB
+
+        private async Task TriggerImageUpload()
+        {
+            await Js.InvokeVoidAsync("BlazorRichTextEditor.triggerClick", _imageInput.Element);
+        }
+
+        private async Task TriggerFileUpload()
+        {
+            await Js.InvokeVoidAsync("BlazorRichTextEditor.triggerClick", _fileInput.Element);
+        }
+
+        private async Task UploadImage(InputFileChangeEventArgs e)
+        {
+            if (e.FileCount == 0 || string.IsNullOrEmpty(UploadUrl))
+                return;
+
+            var file = e.File;
+            using var content = new MultipartFormDataContent();
+            var stream = file.OpenReadStream(MaxFileSize);
+            content.Add(new StreamContent(stream)
+            {
+                Headers =
+                {
+                    ContentType = new MediaTypeHeaderValue(file.ContentType)
+                }
+            }, "file", file.Name);
+
+            var response = await Http.PostAsync(UploadUrl, content);
+            if (!response.IsSuccessStatusCode)
+                return;
+
+            var json = await response.Content.ReadAsStringAsync();
+            var url = ParseUrl(json);
+            if (!string.IsNullOrEmpty(url))
+            {
+                await Js.InvokeVoidAsync("BlazorRichTextEditor.insertHtml", _ref, $"<img src='{url}' />");
+                await HandleInput();
+            }
+        }
+
+        private async Task UploadFile(InputFileChangeEventArgs e)
+        {
+            if (e.FileCount == 0 || string.IsNullOrEmpty(UploadUrl))
+                return;
+
+            var file = e.File;
+            using var content = new MultipartFormDataContent();
+            var stream = file.OpenReadStream(MaxFileSize);
+            content.Add(new StreamContent(stream)
+            {
+                Headers =
+                {
+                    ContentType = new MediaTypeHeaderValue(file.ContentType)
+                }
+            }, "file", file.Name);
+
+            var response = await Http.PostAsync(UploadUrl, content);
+            if (!response.IsSuccessStatusCode)
+                return;
+
+            var json = await response.Content.ReadAsStringAsync();
+            var url = ParseUrl(json);
+            if (!string.IsNullOrEmpty(url))
+            {
+                await Js.InvokeVoidAsync("BlazorRichTextEditor.insertHtml", _ref, $"<a href='{url}'>{file.Name}</a>");
+                await HandleInput();
+            }
+        }
+
+        private static string ParseUrl(string json)
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(json);
+                if (doc.RootElement.TryGetProperty("url", out var urlProp))
+                {
+                    return urlProp.GetString();
+                }
+            }
+            catch
+            {
+            }
+            return null;
+        }
+
+        public ValueTask<string> GetValueAsync()
+        {
+            return Js.InvokeAsync<string>("BlazorRichTextEditor.getText", _ref);
+        }
+
+        public ValueTask<string> GetHtmlAsync()
+        {
+            return Js.InvokeAsync<string>("BlazorRichTextEditor.getHtml", _ref);
+        }
+
+        public async Task SetValueAsync(string value)
+        {
+            await Js.InvokeVoidAsync("BlazorRichTextEditor.setText", _ref, value);
+            await HandleInput();
+        }
+
+        public async Task SetHtmlAsync(string html)
+        {
+            await Js.InvokeVoidAsync("BlazorRichTextEditor.setHtml", _ref, html);
+            await HandleInput();
+        }
+
+        public async Task SetHeight(string value)
+        {
+            Height = value;
+            await Js.InvokeVoidAsync("BlazorRichTextEditor.setDimensions", _ref, Width, Height);
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/RichTextEditor/wwwroot/rich-text-editor.css
+++ b/src/RichTextEditor/wwwroot/rich-text-editor.css
@@ -1,0 +1,12 @@
+[data-placeholder]:empty:before {
+    content: attr(data-placeholder);
+    color: #aaa;
+}
+
+.rte-toolbar {
+    margin-bottom: 4px;
+}
+
+.rte-toolbar button {
+    margin-right: 2px;
+}

--- a/src/RichTextEditor/wwwroot/rich-text-editor.js
+++ b/src/RichTextEditor/wwwroot/rich-text-editor.js
@@ -1,0 +1,34 @@
+window.BlazorRichTextEditor = {
+    getText: function(el) { return el.innerText; },
+    getHtml: function(el) { return el.innerHTML; },
+    setHtml: function(el, html) { el.innerHTML = html || ''; },
+    setDimensions: function(el, width, height) {
+        if (width) el.style.width = width;
+        if (height) el.style.height = height;
+    },
+    setPlaceholder: function(el, text) {
+        if (text == null) text = '';
+        el.setAttribute('data-placeholder', text);
+    },
+    execCommand: function(el, command, arg) {
+        el.focus();
+        document.execCommand(command, false, arg);
+    },
+    createLink: function(el) {
+        var url = prompt('Enter URL');
+        if (url) {
+            el.focus();
+            document.execCommand('createLink', false, url);
+        }
+    },
+    triggerClick: function(el) {
+        if (el) el.click();
+    },
+    insertHtml: function(el, html) {
+        el.focus();
+        document.execCommand('insertHTML', false, html);
+    },
+    setText: function(el, text) {
+        el.innerText = text || '';
+    }
+};

--- a/src/UEditor.Docs.Server/Pages/_Host.cshtml
+++ b/src/UEditor.Docs.Server/Pages/_Host.cshtml
@@ -38,6 +38,8 @@
     <script src="_content/UEditorBlazor/neditor.all.min.js"></script>
     <script src="_content/UEditorBlazor/neditor.service.js"></script>
     <script src="_content/UEditorBlazor/ueditor-blazor.js"></script>
+    <link href="_content/RichTextEditor/rich-text-editor.css" rel="stylesheet" />
+    <script src="_content/RichTextEditor/rich-text-editor.js"></script>
     <script src="_framework/blazor.server.js"></script>
 </body>
 </html>

--- a/src/UEditor.Docs.WebAssembly/wwwroot/index.html
+++ b/src/UEditor.Docs.WebAssembly/wwwroot/index.html
@@ -22,6 +22,8 @@
     <script src="_content/UEditorBlazor/neditor.all.min.js"></script>
     <script src="_content/UEditorBlazor/neditor.service.js"></script>
     <script src="_content/UEditorBlazor/ueditor-blazor.js"></script>
+    <link href="_content/RichTextEditor/rich-text-editor.css" rel="stylesheet" />
+    <script src="_content/RichTextEditor/rich-text-editor.js"></script>
 
     <script src="_framework/blazor.webassembly.js"></script>
     <script>navigator.serviceWorker.register('service-worker.js');</script>

--- a/src/UEditor.Docs/Pages/EditorDemo.razor
+++ b/src/UEditor.Docs/Pages/EditorDemo.razor
@@ -1,0 +1,14 @@
+@page "/editor-demo"
+
+<h3>Rich Text Editor Demo</h3>
+
+<RichTextEditor.RichTextEditor @ref="editor" @bind-Value="value" @bind-Html="html" Height="300px" Width="600px" Placeholder="Type here..." />
+
+<p>Text: @value</p>
+<p>@((MarkupString)html)</p>
+
+@code {
+    private string value = string.Empty;
+    private string html = string.Empty;
+    private RichTextEditor.RichTextEditor editor;
+}

--- a/src/UEditor.Docs/Shared/NavMenu.razor
+++ b/src/UEditor.Docs/Shared/NavMenu.razor
@@ -17,6 +17,11 @@
                 <span class="oi oi-plus" aria-hidden="true"></span> Multiple
             </NavLink>
         </li>
+        <li class="nav-item px-3">
+            <NavLink class="nav-link" href="editor-demo">
+                <span class="oi oi-pencil" aria-hidden="true"></span> RichText Demo
+            </NavLink>
+        </li>
         @* <li class="nav-item px-3">
             <NavLink class="nav-link" href="fetchdata">
                 <span class="oi oi-list-rich" aria-hidden="true"></span> Fetch data

--- a/src/UEditor.Docs/UEditor.Docs.csproj
+++ b/src/UEditor.Docs/UEditor.Docs.csproj
@@ -7,5 +7,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\UEditor\UEditor.csproj" />
+    <ProjectReference Include="..\RichTextEditor\RichTextEditor.csproj" />
   </ItemGroup>
 </Project>

--- a/src/UEditor.Docs/_Imports.razor
+++ b/src/UEditor.Docs/_Imports.razor
@@ -4,3 +4,5 @@
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.JSInterop
 @using UEditor.Docs.Shared
+@using RichTextEditor
+


### PR DESCRIPTION
## Summary
- add RichTextEditor demo page at `/editor-demo`
- include RichTextEditor styles and scripts in sample hosts
- reference the new library from docs and solution
- update navigation menu with a demo link

## Testing
- `dotnet build UEditor.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e67c09e088333b4d961ea2ab243bc